### PR TITLE
Small fixes for text extraction

### DIFF
--- a/privacy_bot/mining/fetch_policies.py
+++ b/privacy_bot/mining/fetch_policies.py
@@ -16,6 +16,7 @@ import os.path
 
 from readability.readability import Document
 import docopt
+import html
 import html2text
 import langdetect
 import tldextract
@@ -63,6 +64,11 @@ def fetch_privacy_policy(policy_url):
     html_converter.skip_internal_links = True
 
     text = html_converter.handle(content)
+
+    try:
+        text = html.unescape(text)
+    except Exception as e:
+        print('Error unescaping html:', e)
 
     try:
         lang = langdetect.detect(text)

--- a/privacy_bot/mining/fetcher.py
+++ b/privacy_bot/mining/fetcher.py
@@ -73,6 +73,13 @@ def fetch(url, max_retry=3, verbose=False):
                 allow_redirects=True,
                 timeout=5
             )
+            
+            if response.encoding and response.encoding.lower() != 'utf-8':
+                try:
+                    return response.text.encode(response.encoding).decode('utf-8')
+                except UnicodeError:
+                    logging.exception('Error converting to unicode from {}'.format(response.encoding))
+
             return response.text
         except:
             if verbose:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "requests==2.14.2",
         "selenium==3.4.2",
         "tldextract==2.0.2",
+        "html2text==2016.9.19",
     ],
     long_description=LONG_DESCRIPTION,
     classifiers=[


### PR DESCRIPTION
Example for google.de:

Before: `DatenschutzerklÃ¤rung â DatenschutzerklÃ¤rung &amp; Nutzungsbedingungen â Google`
After: `Datenschutzerklärung – Datenschutzerklärung & Nutzungsbedingungen – Google`